### PR TITLE
Fix `newfs_hfs` failing due to extra space in `hdid` output

### DIFF
--- a/Contents/MacOS/startupRAMDiskandCacheMover.sh
+++ b/Contents/MacOS/startupRAMDiskandCacheMover.sh
@@ -23,7 +23,7 @@ ramfs_size_mb=$((${ramfs_size_mb} / 1024 / 1024 / 4))
 
 mount_point=/Users/${USER}/ramdisk
 ramfs_size_sectors=$((${ramfs_size_mb}*1024*1024/512))
-ramdisk_device=`hdid -nomount ram://${ramfs_size_sectors}`
+ramdisk_device=`hdid -nomount ram://${ramfs_size_sectors} | tr -d '[:space:]`
 USERRAMDISK="$mount_point"
 
 MSG_MOVE_CACHE=". Do you want me to move its cache? Note: It will close the app."

--- a/Contents/MacOS/startupRAMDiskandCacheMover.sh
+++ b/Contents/MacOS/startupRAMDiskandCacheMover.sh
@@ -23,7 +23,7 @@ ramfs_size_mb=$((${ramfs_size_mb} / 1024 / 1024 / 4))
 
 mount_point=/Users/${USER}/ramdisk
 ramfs_size_sectors=$((${ramfs_size_mb}*1024*1024/512))
-ramdisk_device=`hdid -nomount ram://${ramfs_size_sectors} | tr -d '[:space:]`
+ramdisk_device=`hdid -nomount ram://${ramfs_size_sectors} | tr -d '[:space:]'`
 USERRAMDISK="$mount_point"
 
 MSG_MOVE_CACHE=". Do you want me to move its cache? Note: It will close the app."


### PR DESCRIPTION
## What it does?
- Should fix execution (probably broken due to High Sierra update).
- Clear trailing space in `hdiutil` output, to prevent `newfs_hfs` failing with message:
```sh
newfs_hfs: cannot create filesystem on /dev/rdisk1          	                               	: No such file or directory
```

## I have tested it on
- macOS High Sierra 13.1
