### PR TITLE
Feature/brave cache

### DIFF
--- a/Contents/MacOS/startupRAMDiskandCacheMover.sh
+++ b/Contents/MacOS/startupRAMDiskandCacheMover.sh
@@ -231,21 +231,21 @@ link_brave_dir()
 check_brave_cache()
 {
     if [ -d "/Users/${USER}/Library/Caches/BraveSoftware/Brave-Browser" ]; then
-	if user_response "${MSG_PROMPT_FOUND}" 'Brave'"${MSG_MOVE_CACHE}" ; then
+        if user_response "${MSG_PROMPT_FOUND}" 'Brave'"${MSG_MOVE_CACHE}" ; then
             close_app "Brave Browser"
-	    make_brave_dir
-	    move_brave_cache
-	    link_brave_dir
+            make_brave_dir
+            move_brave_cache
+            link_brave_dir
             /bin/rm -rf /tmp/Brave-Browser
             # and let's create a flag for next run that we moved the cache.
             echo "";
-	fi
+        fi
     elif [ -L "/Users/${USER}/Library/Caches/BraveSoftware/Brave-Browser" ]; then
-	echo "Brave cache already moved"
+        echo "Brave cache already moved"
         close_app "Brave Browser"
-	make_brave_dir
+        make_brave_dir
     else
-	echo "No Brave folder has been found. Skipping."
+        echo "No Brave folder has been found. Skipping."
     fi
 }
 

--- a/Contents/MacOS/startupRAMDiskandCacheMover.sh
+++ b/Contents/MacOS/startupRAMDiskandCacheMover.sh
@@ -202,6 +202,29 @@ move_chrome_chanary_cache()
 }
 
 #
+# Brave Cache
+#
+move_brave_cache()
+{
+   if [ -d "/Users/${USER}/Library/Caches/BraveSoftware/Brave-Browser" ]; then
+      if user_response "${MSG_PROMPT_FOUND}" 'Brave'"${MSG_MOVE_CACHE}" ; then
+         close_app "Brave Browser"
+         /bin/mkdir -p /tmp/Brave-Browser
+         /bin/mv ~/Library/Caches/BraveSoftware/Brave-Browser/* /tmp/Brave-Browser
+         /bin/mkdir -pv "${USERRAMDISK}"/Brave-Browser
+         /bin/mv /tmp/Brave-Browser/* "${USERRAMDISK}"/Brave-Browser
+         /bin/rm -rf ~/Library/Caches/BraveSoftware/Brave-Browser
+         /bin/ln -v -s "${USERRAMDISK}"/Brave-Browser ~/Library/Caches/BraveSoftware/Brave-Browser
+         /bin/rm -rf /tmp/Brave-Browser
+         # and let's create a flag for next run that we moved the cache.
+         echo "";
+      fi
+   else
+      echo "No Brave folder has been found. Skipping."
+   fi
+}
+
+#
 # Safari Cache
 #
 move_safari_cache()
@@ -386,6 +409,7 @@ main() {
    move_safari_cache
    move_idea_cache
    move_ideace_cache
+   move_brave_cache
    # create intermediate folder for intellij projects output
    create_intermediate_folder_for_intellij_projects
    move_itunes_cache

--- a/Contents/MacOS/startupRAMDiskandCacheMover.sh
+++ b/Contents/MacOS/startupRAMDiskandCacheMover.sh
@@ -204,24 +204,49 @@ move_chrome_chanary_cache()
 #
 # Brave Cache
 #
+
+# Create a directory for Brave in the ramdisk
+make_brave_dir()
+{
+    /bin/mkdir -pv "${USERRAMDISK}"/Brave-Browser
+}
+
+# Move existing Brave cache to ramdisk
 move_brave_cache()
 {
-   if [ -d "/Users/${USER}/Library/Caches/BraveSoftware/Brave-Browser" ]; then
-      if user_response "${MSG_PROMPT_FOUND}" 'Brave'"${MSG_MOVE_CACHE}" ; then
-         close_app "Brave Browser"
-         /bin/mkdir -p /tmp/Brave-Browser
-         /bin/mv ~/Library/Caches/BraveSoftware/Brave-Browser/* /tmp/Brave-Browser
-         /bin/mkdir -pv "${USERRAMDISK}"/Brave-Browser
-         /bin/mv /tmp/Brave-Browser/* "${USERRAMDISK}"/Brave-Browser
-         /bin/rm -rf ~/Library/Caches/BraveSoftware/Brave-Browser
-         /bin/ln -v -s "${USERRAMDISK}"/Brave-Browser ~/Library/Caches/BraveSoftware/Brave-Browser
-         /bin/rm -rf /tmp/Brave-Browser
-         # and let's create a flag for next run that we moved the cache.
-         echo "";
-      fi
-   else
-      echo "No Brave folder has been found. Skipping."
-   fi
+    /bin/mkdir -p /tmp/Brave-Browser
+    /bin/mv ~/Library/Caches/BraveSoftware/Brave-Browser/* /tmp/Brave-Browser
+    /bin/mv /tmp/Brave-Browser/* "${USERRAMDISK}"/Brave-Browser
+    /bin/rm -rf ~/Library/Caches/BraveSoftware/Brave-Browser
+    
+}
+
+# Link Brave cache to ramdisk
+link_brave_dir()
+{
+    /bin/ln -v -s "${USERRAMDISK}"/Brave-Browser ~/Library/Caches/BraveSoftware/Brave-Browser
+}
+
+# Check what to do with brave
+check_brave_cache()
+{
+    if [ -d "/Users/${USER}/Library/Caches/BraveSoftware/Brave-Browser" ]; then
+	if user_response "${MSG_PROMPT_FOUND}" 'Brave'"${MSG_MOVE_CACHE}" ; then
+            close_app "Brave Browser"
+	    make_brave_dir
+	    move_brave_cache
+	    link_brave_dir
+            /bin/rm -rf /tmp/Brave-Browser
+            # and let's create a flag for next run that we moved the cache.
+            echo "";
+	fi
+    elif [ -L "/Users/${USER}/Library/Caches/BraveSoftware/Brave-Browser" ]; then
+	echo "Brave cache already moved"
+        close_app "Brave Browser"
+	make_brave_dir
+    else
+	echo "No Brave folder has been found. Skipping."
+    fi
 }
 
 #
@@ -409,7 +434,7 @@ main() {
    move_safari_cache
    move_idea_cache
    move_ideace_cache
-   move_brave_cache
+   check_brave_cache
    # create intermediate folder for intellij projects output
    create_intermediate_folder_for_intellij_projects
    move_itunes_cache

--- a/README.md
+++ b/README.md
@@ -14,6 +14,7 @@ Supported apps (you can add yours):
 * [IntelliJ Idea 14/15](https://www.jetbrains.com/idea/download/)
 * [Google Chrome](https://support.google.com/chrome/answer/95346?hl=en)
 * [Google Canary](https://www.google.com/chrome/browser/canary.html)
+* [Brave](https://brave.com/)
 * Safari
 * iTunes
 * [Android studio](http://developer.android.com/sdk/index.html)


### PR DESCRIPTION
## What it does?
- Moves [Brave Browser](https://brave.com)'s cache to ramdisk, if not yet moved
- Makes an empty directory for Brave in the ramdisk if the cache was already moved before
- Makes Brave fast as hell

## I have tested it on
- macOS 10.15.3 Catalina on a hackintosh, MBP 15" mid 2012 and MBPr 15" late 2013

# NOTICE
I based my solution on Chromium's cache moving and I noticed that the `-f` and `-F` for `ln` don't seem to have any effect on Catalina. All caches that use these flags don't work on Catalina for me, so I made a workaround for Brave. I'd be happy to do the same workaround for other browsers, but I didn't want to mix things together